### PR TITLE
Reimplement X11 backend using xcb instead of Xlib.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,9 @@ features = [
 ]
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
-x11-dl = "2.21"
+itertools = "0.12.1"
+x11-dl = { version = "2.21", default-features = false }
+x11rb = { version = "0.13.0", features = ["dl-libxcb"] }
 
 [dev-dependencies]
 winit = "0.29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ features = [
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
 itertools = "0.12.1"
 x11-dl = { version = "2.21", default-features = false }
-x11rb = { version = "0.13.0", features = ["dl-libxcb"] }
+x11rb = "0.13.0"
 
 [dev-dependencies]
 winit = "0.29"


### PR DESCRIPTION
## Description

This replaces the Xlib-based implementation of the X11 backend with one that uses xcb.

The main reason for this is that Xlib is pretty thread-unsafe (you can do it but it's tricky), and xcb is much more robust to being used in a threaded context.  Both the existing and updated implementations here use a background thread for the event handling, and as such, xcb is a far superior choice of backing library.

Additionally, the existing implementation was not properly handling errors - it treated the return value from `XGrabKey` as an error code, but the documentation for said function states that it always returns the value `1`.  With Xlib, the appropriate way to get an error is to do a force sync with the X server and then check the latest error event, which is much more complicated than using an xcb cookie to explicitly retrieve the error for a particular X request.

I have generally followed the `global-hotkey` coding conventions here, e.g.: use of a debug assertions-gated `eprintln!()` for logging errors.

## Testing

I manually tested this - registration and unregistration work, errors due to conflicts with existing grabs are handled properly, and key repeat is properly handled (only one hotkey event when the keys are released).